### PR TITLE
Learn about apis with project examples

### DIFF
--- a/apps/fhir/api_views.py
+++ b/apps/fhir/api_views.py
@@ -7,6 +7,9 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required, permission_required
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from django.core.exceptions import ValidationError
 from django.db import transaction
 import json
@@ -15,8 +18,8 @@ from .models import FHIRMergeConfiguration, FHIRMergeConfigurationAudit
 from .configuration import MergeConfigurationService
 
 
-@login_required
-@require_http_methods(["GET"])
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
 def list_configurations(request):
     """
     API endpoint to list FHIR merge configuration profiles.
@@ -28,7 +31,7 @@ def list_configurations(request):
     
     try:
         configurations = MergeConfigurationService.list_configurations(active_only=active_only)
-        
+
         config_data = []
         for config in configurations:
             config_data.append({
@@ -45,15 +48,15 @@ def list_configurations(request):
                 'created_at': config.created_at.isoformat(),
                 'updated_at': config.updated_at.isoformat()
             })
-        
-        return JsonResponse({
+
+        return Response({
             'status': 'success',
             'data': config_data,
             'count': len(config_data)
         })
-        
+
     except Exception as e:
-        return JsonResponse({
+        return Response({
             'status': 'error',
             'message': str(e)
         }, status=500)


### PR DESCRIPTION
Convert `list_configurations` API endpoint to use DRF function-based view.

This change is the first step in a lesson plan to teach the user how to incrementally adopt Django REST Framework, starting with the simplest read-only endpoint.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc92b596-6791-4c78-907d-29fd4759d6c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc92b596-6791-4c78-907d-29fd4759d6c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

